### PR TITLE
Remove YAML document marker from Ansible inventory

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,5 +1,3 @@
----
-
 [leaf]
 leaf01
 leaf02


### PR DESCRIPTION
The inventory file is in INI format, but nevertheless included a YAML
document marker. This caused Ansible to believe a host named «---»
existed:

```
$ ansible all --list-hosts
  hosts (15):
    ---
    leaf01
[...]
```